### PR TITLE
feat(executor): Kraken dry-run config, baseline strategy, and setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@
 EXCHANGE_API_KEY=your_read_only_api_key_here
 EXCHANGE_API_SECRET=your_api_secret_here
 
-# Exchange name (e.g. binance, kraken)
-EXCHANGE_NAME=binance
+# Exchange name — Kraken is recommended for US-based users
+EXCHANGE_NAME=kraken
 
 # Trading mode — keep as "paper" until Layer 6 is justified by sustained evidence
 # Options: paper | live

--- a/.gitignore
+++ b/.gitignore
@@ -212,6 +212,8 @@ __marimo__/
 user_data/
 *.db
 *.sqlite
+*.sqlite-shm
+*.sqlite-wal
 
 # Large market data files
 data/

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,68 @@
+# Setup Guide
+
+## Prerequisites
+
+- Python 3.10+
+- Git
+
+## First-time setup
+
+```powershell
+# Clone the repo
+git clone https://github.com/f1cklepickle/crypto-strategy-lab.git
+cd crypto-strategy-lab
+
+# Create and activate virtual environment
+python -m venv venv
+venv\Scripts\activate        # Windows
+# source venv/bin/activate   # macOS / Linux
+
+# Install dependencies
+pip install freqtrade pydantic
+
+# Copy env file — never commit .env
+copy .env.example .env
+```
+
+## Initialize Freqtrade user data directory
+
+This creates the `user_data/` folder Freqtrade needs at runtime.
+It is gitignored — run this once after cloning.
+
+```powershell
+freqtrade create-userdir --userdir user_data
+```
+
+## Validate the schema
+
+```powershell
+python schemas/validate_schema.py
+```
+
+## Run the bot in dry-run (paper) mode
+
+```powershell
+freqtrade trade --config executor/config.json --strategy BaselineStrategy
+```
+
+Freqtrade will connect to Binance public market data.
+No API key is required for paper trading.
+
+## Download historical data for backtesting
+
+```powershell
+freqtrade download-data --config executor/config.json --days 90 --timeframe 1h
+```
+
+## Run a backtest
+
+```powershell
+freqtrade backtesting --config executor/config.json --strategy BaselineStrategy --timerange 20250101-20260101
+```
+
+## Security reminders
+
+- Never add real API keys until Layer 6 is reached and justified
+- If a key is ever added, it must be read-only with zero trading permissions
+- Keys go in `.env` only — never in `config.json` or anywhere in the repo
+- Run `git status` before every commit to confirm no secrets are staged

--- a/executor/config.json
+++ b/executor/config.json
@@ -1,0 +1,88 @@
+{
+    "max_open_trades": 3,
+    "stake_currency": "USDT",
+    "stake_amount": 100,
+    "tradable_balance_ratio": 0.99,
+    "fiat_display_currency": "USD",
+
+    "dry_run": true,
+    "dry_run_wallet": 1000,
+
+    "cancel_open_orders_on_exit": false,
+
+    "trading_mode": "spot",
+    "margin_mode": "",
+
+    "unfilledtimeout": {
+        "entry": 10,
+        "exit": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
+    },
+
+    "entry_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1,
+        "price_last_balance": 0.0,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+
+    "exit_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1
+    },
+
+    "exchange": {
+        "name": "kraken",
+        "key": "",
+        "secret": "",
+        "ccxt_config": {},
+        "ccxt_async_config": {},
+        "pair_whitelist": [
+            "BTC/USDT",
+            "ETH/USDT",
+            "SOL/USDT"
+        ],
+        "pair_blacklist": []
+    },
+
+    "pairlists": [
+        {
+            "method": "StaticPairList"
+        }
+    ],
+
+    "telegram": {
+        "enabled": false,
+        "token": "",
+        "chat_id": ""
+    },
+
+    "api_server": {
+        "enabled": false,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8080,
+        "verbosity": "error",
+        "enable_openapi": false,
+        "jwt_secret_key": "",
+        "ws_token": "",
+        "CORS_origins": [],
+        "username": "",
+        "password": ""
+    },
+
+    "bot_name": "crypto-strategy-lab-layer0",
+    "initial_state": "running",
+    "force_entry_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    },
+
+    "strategy": "BaselineStrategy",
+    "strategy_path": "strategies/"
+}

--- a/strategies/BaselineStrategy.py
+++ b/strategies/BaselineStrategy.py
@@ -1,0 +1,129 @@
+"""
+BaselineStrategy.py
+
+Layer 0 — Baseline paper trading strategy for crypto-strategy-lab.
+
+Logic:
+    Entry:  EMA20 crosses above EMA50 AND RSI(14) is between 35 and 65
+            (avoids chasing overbought entries)
+    Exit:   EMA20 crosses below EMA50 OR take-profit / stop-loss hit
+
+This strategy is intentionally simple and explainable. The goal is not
+profit — it is to prove the engine runs and logs are clean.
+
+Parameter values here match Variant B from /variants/. Variants A and C
+will be tested in Layer 1.
+"""
+
+from freqtrade.strategy import IStrategy, IntParameter, DecimalParameter
+from pandas import DataFrame
+import talib.abstract as ta
+
+
+class BaselineStrategy(IStrategy):
+    """
+    EMA crossover strategy with RSI filter.
+    Variant B parameter set (EMA 20/50, RSI 35-65, ATR stop 2.0x).
+    """
+
+    # --- Strategy metadata ------------------------------------------------
+
+    INTERFACE_VERSION = 3
+    timeframe = "1h"
+    can_short = False
+
+    # Minimal ROI — let stop-loss and trailing stop do the work
+    minimal_roi = {
+        "0": 0.10,   # 10% take-profit as a safety ceiling
+    }
+
+    # Stop loss: -3% hard stop (ATR-based refinement comes in Layer 3)
+    stoploss = -0.03
+
+    # Trailing stop disabled for Layer 0 — keep it simple and measurable
+    trailing_stop = False
+
+    # Allow buying on the same candle as a sell signal
+    process_only_new_candles = True
+
+    # Startup candle count — need at least 50 candles for EMA50
+    startup_candle_count = 60
+
+    # --- Parameters (Variant B defaults) ----------------------------------
+    # These are defined as parameters so later layers can vary them
+    # without modifying this file.
+
+    ema_short = IntParameter(10, 30, default=20, space="buy", optimize=False)
+    ema_long = IntParameter(30, 60, default=50, space="buy", optimize=False)
+    rsi_low = IntParameter(25, 45, default=35, space="buy", optimize=False)
+    rsi_high = IntParameter(55, 75, default=65, space="buy", optimize=False)
+
+    # --- Indicator calculation --------------------------------------------
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Calculate all indicators needed for entry/exit signals.
+        All indicator values are logged by Freqtrade automatically.
+        """
+
+        # EMAs
+        dataframe["ema_short"] = ta.EMA(dataframe, timeperiod=self.ema_short.value)
+        dataframe["ema_long"] = ta.EMA(dataframe, timeperiod=self.ema_long.value)
+
+        # RSI
+        dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
+
+        # ATR (for context logging — not used in stop yet, that's Layer 3)
+        dataframe["atr"] = ta.ATR(dataframe, timeperiod=14)
+
+        # EMA crossover signals
+        dataframe["ema_cross_up"] = (
+            (dataframe["ema_short"] > dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) <= dataframe["ema_long"].shift(1))
+        )
+        dataframe["ema_cross_down"] = (
+            (dataframe["ema_short"] < dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) >= dataframe["ema_long"].shift(1))
+        )
+
+        return dataframe
+
+    # --- Entry signal -----------------------------------------------------
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Entry condition:
+            EMA20 crosses above EMA50
+            AND RSI is between 35 and 65 (not overbought, not oversold)
+        """
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_up"] &
+                (dataframe["rsi"] >= self.rsi_low.value) &
+                (dataframe["rsi"] <= self.rsi_high.value) &
+                (dataframe["volume"] > 0)
+            ),
+            "enter_long"
+        ] = 1
+
+        return dataframe
+
+    # --- Exit signal ------------------------------------------------------
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        """
+        Exit condition:
+            EMA20 crosses below EMA50 (trend reversal signal)
+        Hard stop-loss and minimal_roi handle the rest.
+        """
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_down"] &
+                (dataframe["volume"] > 0)
+            ),
+            "exit_long"
+        ] = 1
+
+        return dataframe


### PR DESCRIPTION
## Summary
- Adds Freqtrade dry-run config pointed at Kraken (US-accessible exchange)
- Adds BaselineStrategy — EMA 20/50 crossover with RSI 14 filter (Variant B parameter set)
- Extends .gitignore to cover Freqtrade runtime files (SQLite WAL, logs, data)
- Updates .env.example to reflect Kraken as the recommended exchange for US users
- Adds docs/setup.md with full setup, run, and security instructions

## Test plan
- [x] Freqtrade connects to Kraken public data in dry-run mode
- [x] Bot enters RUNNING state with correct config (confirmed in logs)
- [x] No API keys, secrets, or runtime DB files committed

Closes #2