### PR TITLE
feat(executor): trade frequency update — 15m timeframe, 5 max trades, 6 pairs

### DIFF
--- a/executor/config.json
+++ b/executor/config.json
@@ -1,12 +1,12 @@
 {
-    "max_open_trades": 3,
+    "max_open_trades": 5,
     "stake_currency": "USDT",
     "stake_amount": 100,
     "tradable_balance_ratio": 0.99,
     "fiat_display_currency": "USD",
 
     "dry_run": true,
-    "dry_run_wallet": 1000,
+    "dry_run_wallet": 1500,
 
     "cancel_open_orders_on_exit": false,
 
@@ -46,7 +46,10 @@
         "pair_whitelist": [
             "BTC/USDT",
             "ETH/USDT",
-            "SOL/USDT"
+            "SOL/USDT",
+            "XRP/USDT",
+            "ADA/USDT",
+            "LINK/USDT"
         ],
         "pair_blacklist": []
     },

--- a/strategies/BaselineStrategy.py
+++ b/strategies/BaselineStrategy.py
@@ -29,7 +29,7 @@ class BaselineStrategy(IStrategy):
     # --- Strategy metadata ------------------------------------------------
 
     INTERFACE_VERSION = 3
-    timeframe = "1h"
+    timeframe = "15m"
     can_short = False
 
     # Minimal ROI — let stop-loss and trailing stop do the work
@@ -47,6 +47,7 @@ class BaselineStrategy(IStrategy):
     process_only_new_candles = True
 
     # Startup candle count — need at least 50 candles for EMA50
+    # On 15m timeframe this covers ~12.5 hours of history
     startup_candle_count = 60
 
     # --- Parameters (Variant B defaults) ----------------------------------

--- a/variants/variant_a.json
+++ b/variants/variant_a.json
@@ -5,7 +5,7 @@
     "layer": 1,
 
     "strategy": "BaselineStrategy",
-    "timeframe": "1h",
+    "timeframe": "15m",
 
     "parameters": {
         "ema_short": 10,

--- a/variants/variant_b.json
+++ b/variants/variant_b.json
@@ -5,7 +5,7 @@
     "layer": 0,
 
     "strategy": "BaselineStrategy",
-    "timeframe": "1h",
+    "timeframe": "15m",
 
     "parameters": {
         "ema_short": 20,

--- a/variants/variant_c.json
+++ b/variants/variant_c.json
@@ -5,7 +5,7 @@
     "layer": 1,
 
     "strategy": "BaselineStrategy",
-    "timeframe": "1h",
+    "timeframe": "15m",
 
     "parameters": {
         "ema_short": 15,


### PR DESCRIPTION
## Summary
- Switches strategy timeframe from 1h → 15m to accelerate signal generation
- Expands pair whitelist from 3 → 6 (adds XRP/USDT, ADA/USDT, LINK/USDT)
- Increases max_open_trades from 3 → 5
- Increases dry_run_wallet from 1000 → 1500 USDT to support additional positions
- Updates all three variants (A/B/C) to 15m timeframe

## Why
1h candles produce ~6 signals/day per pair at most. 15m gives ~96 candle closes/day across 6 pairs — dramatically faster data accumulation for validating PR criteria on #3, #4, and #5.

## Test plan
- [ ] Bot restarts without errors
- [ ] Log shows `Whitelist with 6 pairs` on startup
- [ ] First trade opens within 24h
- [ ] Closed trades appear in Freqtrade SQLite DB

Closes #11