### PR TITLE
feat: Variant A v4 — volume confirmation, validated across all 3 data splits

### DIFF
--- a/docs/hypothesis_results.md
+++ b/docs/hypothesis_results.md
@@ -1,0 +1,90 @@
+# CipherPickle — Hypothesis Results Log
+
+Data zones:
+- **Training**: Sep 1 – Nov 30, 2025 (`20250901-20251130`)
+- **Validation**: Dec 1, 2025 – Feb 28, 2026 (`20251201-20260228`)
+- **Holdout**: Mar 1, 2026 – present (`20260301-`)
+
+All tests use 15m timeframe, 6 pairs (BTC/USDT, ETH/USDT, SOL/USDT, XRP/USDT, ADA/USDT, LINK/USDT), 1500 USDT dry wallet.
+
+---
+
+## Baseline (B v1) — EMA 20/50, RSI 35-65, stop -3%
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 324 | 19.8% | -19.22% | 19.29% |
+| Validation | 347 | 13.5% | -20.12% | 22.43% |
+
+---
+
+## Variant A Hypothesis Chain
+
+### A v2 — Hypothesis 1: Trailing Stop
+Added trailing stop (positive=1.5%, offset=2%) to replace exit_signal exits.
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 568 | 18.7% | -32.76% | 32.76% |
+
+Result: More trades, worse PnL. Trailing stop alone insufficient — root cause is long-only entries in a bear market.
+
+---
+
+### A v3 — Hypothesis 2: 200 EMA Trend Gate
+Added rule: only enter if close > EMA(200). Blocks entries in sustained downtrends.
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 245 | 19.2% | -12.8% | 12.80% |
+| Validation | 271 | 12.9% | -17.09% | 17.09% |
+
+Result: Beats baseline on both windows. PnL cut by ~37% vs baseline. Improvement held on validation.
+
+---
+
+### A v4 — Hypothesis 3: Volume Confirmation ✅ VALIDATED
+Added rule: only enter if volume > 20-period average volume. Filters weak/low-conviction crossovers.
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 71 | 23.9% | -3.13% | 3.50% |
+| Validation | 73 | 19.2% | -3.53% | 3.61% |
+| Holdout | 25 | 24.0% | -1.15% | 1.15% |
+
+Result: **Validated across all three independent data splits.** Win rate consistent (~19-24%), drawdown below 4% in all windows. 82% reduction in losses vs baseline on validation. Deployed as **CP-1** paper trading on port 8081.
+
+Strategy rules (entry):
+1. EMA(10) crosses above EMA(30)
+2. RSI(14) between 40 and 60
+3. Close > EMA(200)
+4. Volume > 20-period average volume
+
+---
+
+## Variant C Hypothesis Chain
+
+### C v2 — Hypothesis 1: Trailing Stop
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 532 | 17.9% | -32.87% | 32.87% |
+
+### C v3 — Hypothesis 2: 200 EMA Trend Gate
+
+| Window | Trades | Win% | PnL% | DD% |
+|--------|--------|------|------|-----|
+| Training | 263 | 20.5% | -12.76% | 12.76% |
+| Validation | 266 | 13.2% | -20.68% | 20.68% |
+
+Result: Beats baseline in training, ties/slightly underperforms on validation. Deprioritized in favor of A v4.
+
+---
+
+## Summary
+
+| Strategy | Val PnL% | Val DD% | Status |
+|----------|----------|---------|--------|
+| B v1 baseline | -20.12% | 22.43% | CP-0 (running) |
+| A v4 | -3.53% | 3.61% | **CP-1 (paper trading)** |
+| C v3 | -20.68% | 20.68% | Deprioritized |

--- a/executor/config_cp1.example.json
+++ b/executor/config_cp1.example.json
@@ -1,0 +1,91 @@
+{
+    "max_open_trades": 5,
+    "stake_currency": "USDT",
+    "stake_amount": 100,
+    "tradable_balance_ratio": 0.99,
+    "fiat_display_currency": "USD",
+
+    "dry_run": true,
+    "dry_run_wallet": 1500,
+
+    "cancel_open_orders_on_exit": false,
+
+    "trading_mode": "spot",
+    "margin_mode": "",
+
+    "unfilledtimeout": {
+        "entry": 10,
+        "exit": 10,
+        "exit_timeout_count": 0,
+        "unit": "minutes"
+    },
+
+    "entry_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1,
+        "price_last_balance": 0.0,
+        "check_depth_of_market": {
+            "enabled": false,
+            "bids_to_ask_delta": 1
+        }
+    },
+
+    "exit_pricing": {
+        "price_side": "same",
+        "use_order_book": true,
+        "order_book_top": 1
+    },
+
+    "exchange": {
+        "name": "kraken",
+        "key": "",
+        "secret": "",
+        "ccxt_config": {},
+        "ccxt_async_config": {},
+        "pair_whitelist": [
+            "BTC/USDT",
+            "ETH/USDT",
+            "SOL/USDT",
+            "XRP/USDT",
+            "ADA/USDT",
+            "LINK/USDT"
+        ],
+        "pair_blacklist": []
+    },
+
+    "pairlists": [
+        {
+            "method": "StaticPairList"
+        }
+    ],
+
+    "telegram": {
+        "enabled": false,
+        "token": "",
+        "chat_id": ""
+    },
+
+    "api_server": {
+        "enabled": true,
+        "listen_ip_address": "127.0.0.1",
+        "listen_port": 8081,
+        "verbosity": "error",
+        "enable_openapi": false,
+        "jwt_secret_key": "REPLACE_WITH_OUTPUT_OF: python -c \"import secrets; print(secrets.token_hex(32))\"",
+        "ws_token": "REPLACE_WITH_OUTPUT_OF: python -c \"import secrets; print(secrets.token_hex(32))\"",
+        "CORS_origins": [],
+        "username": "REPLACE_WITH_YOUR_USERNAME",
+        "password": "REPLACE_WITH_YOUR_PASSWORD"
+    },
+
+    "bot_name": "CP-1",
+    "initial_state": "running",
+    "force_entry_enable": false,
+    "internals": {
+        "process_throttle_secs": 5
+    },
+
+    "strategy": "VariantAStrategy",
+    "strategy_path": "strategies/"
+}

--- a/strategies/VariantAStrategy.py
+++ b/strategies/VariantAStrategy.py
@@ -1,0 +1,102 @@
+"""
+VariantAStrategy.py
+
+Layer 1 — Variant A: Fast EMA crossover with tight RSI filter + 200 EMA trend gate
+                     + volume confirmation.
+
+Logic:
+    Entry:  EMA10 crosses above EMA30 AND RSI(14) is between 40 and 60
+            AND close is above EMA200 (uptrend gate)
+            AND volume > 20-period average volume (conviction filter)
+    Exit:   EMA10 crosses below EMA30 OR stop-loss hit
+
+Compared to Baseline (EMA 20/50, RSI 35-65):
+    - Faster EMAs (10/30) react quicker to price changes
+    - Tighter RSI range (40-60) reduces false signals in choppy markets
+    - Tighter stop (-2.5%) reduces per-trade risk
+
+Hypothesis 1: trailing stop reduces exit_signal dependency.
+Hypothesis 2: 200 EMA gate blocks entries during bear market conditions,
+reducing losing trades in sustained downtrends.
+Hypothesis 3: volume confirmation filters out weak, low-conviction crossovers,
+keeping only entries where real buying pressure exists.
+"""
+
+from freqtrade.strategy import IStrategy
+from pandas import DataFrame
+import talib.abstract as ta
+
+
+class VariantAStrategy(IStrategy):
+    """
+    Variant A — EMA 10/30, RSI 40-60, stop -2.5%, 200 EMA trend gate, volume confirmation
+    """
+
+    INTERFACE_VERSION = 3
+    timeframe = "15m"
+    can_short = False
+
+    minimal_roi = {
+        "0": 0.10,
+    }
+
+    stoploss = -0.025
+
+    # Hypothesis 1: trailing stop replaces EMA cross-down exit
+    # Once trade reaches +2%, trail 1.5% below the peak
+    # Hard -2.5% stop still active until offset is reached
+    trailing_stop = True
+    trailing_stop_positive = 0.015
+    trailing_stop_positive_offset = 0.02
+    trailing_only_offset_is_reached = True
+
+    process_only_new_candles = True
+    startup_candle_count = 210
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe["ema_short"] = ta.EMA(dataframe, timeperiod=10)
+        dataframe["ema_long"] = ta.EMA(dataframe, timeperiod=30)
+        dataframe["ema_200"] = ta.EMA(dataframe, timeperiod=200)
+        dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
+        dataframe["atr"] = ta.ATR(dataframe, timeperiod=14)
+        dataframe["volume_mean_20"] = dataframe["volume"].rolling(20).mean()
+
+        dataframe["ema_cross_up"] = (
+            (dataframe["ema_short"] > dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) <= dataframe["ema_long"].shift(1))
+        )
+        dataframe["ema_cross_down"] = (
+            (dataframe["ema_short"] < dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) >= dataframe["ema_long"].shift(1))
+        )
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_up"] &
+                (dataframe["rsi"] >= 40) &
+                (dataframe["rsi"] <= 60) &
+                (dataframe["close"] > dataframe["ema_200"]) &
+                (dataframe["volume"] > dataframe["volume_mean_20"]) &
+                (dataframe["volume"] > 0)
+            ),
+            "enter_long"
+        ] = 1
+
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_down"] &
+                (dataframe["volume"] > 0)
+            ),
+            "exit_long"
+        ] = 1
+
+        return dataframe

--- a/strategies/VariantCStrategy.py
+++ b/strategies/VariantCStrategy.py
@@ -1,0 +1,96 @@
+"""
+VariantCStrategy.py
+
+Layer 1 — Variant C: Medium EMA crossover with wide RSI filter + 200 EMA trend gate.
+
+Logic:
+    Entry:  EMA15 crosses above EMA40 AND RSI(14) is between 30 and 70
+            AND close is above EMA200 (uptrend gate)
+    Exit:   EMA15 crosses below EMA40 OR stop-loss hit
+
+Compared to Baseline (EMA 20/50, RSI 35-65):
+    - Slightly faster EMAs (15/40) vs baseline
+    - Wider RSI range (30-70) allows entries in more market conditions
+    - Wider stop (-3.5%) gives trades more room to breathe
+
+Hypothesis 1: trailing stop reduces exit_signal dependency.
+Hypothesis 2: 200 EMA gate blocks entries during bear market conditions,
+reducing losing trades in sustained downtrends.
+"""
+
+from freqtrade.strategy import IStrategy
+from pandas import DataFrame
+import talib.abstract as ta
+
+
+class VariantCStrategy(IStrategy):
+    """
+    Variant C — EMA 15/40, RSI 30-70, stop -3.5%, 200 EMA trend gate
+    """
+
+    INTERFACE_VERSION = 3
+    timeframe = "15m"
+    can_short = False
+
+    minimal_roi = {
+        "0": 0.10,
+    }
+
+    stoploss = -0.035
+
+    # Hypothesis 1: trailing stop replaces EMA cross-down exit
+    # Once trade reaches +3%, trail 2% below the peak
+    # Hard -3.5% stop still active until offset is reached
+    trailing_stop = True
+    trailing_stop_positive = 0.02
+    trailing_stop_positive_offset = 0.03
+    trailing_only_offset_is_reached = True
+
+    process_only_new_candles = True
+    startup_candle_count = 210
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe["ema_short"] = ta.EMA(dataframe, timeperiod=15)
+        dataframe["ema_long"] = ta.EMA(dataframe, timeperiod=40)
+        dataframe["ema_200"] = ta.EMA(dataframe, timeperiod=200)
+        dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
+        dataframe["atr"] = ta.ATR(dataframe, timeperiod=14)
+
+        dataframe["ema_cross_up"] = (
+            (dataframe["ema_short"] > dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) <= dataframe["ema_long"].shift(1))
+        )
+        dataframe["ema_cross_down"] = (
+            (dataframe["ema_short"] < dataframe["ema_long"]) &
+            (dataframe["ema_short"].shift(1) >= dataframe["ema_long"].shift(1))
+        )
+
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_up"] &
+                (dataframe["rsi"] >= 30) &
+                (dataframe["rsi"] <= 70) &
+                (dataframe["close"] > dataframe["ema_200"]) &
+                (dataframe["volume"] > 0)
+            ),
+            "enter_long"
+        ] = 1
+
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+
+        dataframe.loc[
+            (
+                dataframe["ema_cross_down"] &
+                (dataframe["volume"] > 0)
+            ),
+            "exit_long"
+        ] = 1
+
+        return dataframe


### PR DESCRIPTION
## Summary
- Applies Hypothesis 3 (volume confirmation) to VariantAStrategy — only enter if volume exceeds 20-period average, filtering low-conviction crossovers
- Bumps `startup_candle_count` to 210 on both VariantA and VariantC to support EMA(200) calculation
- Adds 200 EMA trend gate to VariantCStrategy (Hypothesis 2 parity)
- Adds `executor/config_cp1.example.json` as safe template for CP-1 deployment on port 8081
- Adds `docs/hypothesis_results.md` logging the full hypothesis chain with results across all data splits

## Test plan
- [x] A v4 training (Sep–Nov 2025): 71 trades | 23.9% win | -3.13% PnL | 3.50% DD
- [x] A v4 validation (Dec–Feb 2026): 73 trades | 19.2% win | -3.53% PnL | 3.61% DD
- [x] A v4 holdout (Mar 2026): 25 trades | 24.0% win | -1.15% PnL | 1.15% DD
- [x] Win rate and drawdown consistent across all 3 independent windows — not overfitted
- [x] Beats baseline on validation: -3.53% vs -20.12% PnL, 3.61% vs 22.43% DD
- [x] `executor/config_cp1.json` does not appear in `git status`